### PR TITLE
golang lcs serializer & deserializer implementation round one

### DIFF
--- a/serde-generate/runtime/golang/src/go.mod
+++ b/serde-generate/runtime/golang/src/go.mod
@@ -1,0 +1,5 @@
+module github.com/facebookincubator/serde-reflection
+
+go 1.14
+
+require github.com/stretchr/testify v1.6.1

--- a/serde-generate/runtime/golang/src/go.sum
+++ b/serde-generate/runtime/golang/src/go.sum
@@ -1,0 +1,10 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
+github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/serde-generate/runtime/golang/src/lcs/deserializer.go
+++ b/serde-generate/runtime/golang/src/lcs/deserializer.go
@@ -1,0 +1,198 @@
+// Copyright (c) Facebook, Inc. and its affiliates
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+package lcs
+
+import (
+	"bytes"
+	"errors"
+
+	"github.com/facebookincubator/serde-reflection/serde"
+)
+
+// MaxSequenceLength is max length allowed for sequence
+const MaxSequenceLength = (1 << 31) - 1
+
+const maxUint32 = uint64(^uint32(0))
+
+// Deserializer implements `serde.Deserializer` interface for deserializing LCS serialized bytes
+type Deserializer struct {
+	buf *bytes.Buffer
+}
+
+// NewDeserializer creates a new `serde.Deserializer`
+func NewDeserializer(input []byte) serde.Deserializer {
+	return &Deserializer{buf: bytes.NewBuffer(input)}
+}
+
+func (d *Deserializer) DeserializeBytes() ([]byte, error) {
+	len, err := d.DeserializeLen()
+	if err != nil {
+		return nil, err
+	}
+	ret := make([]byte, len)
+	_, err = d.buf.Read(ret)
+	return ret, err
+}
+
+func (d *Deserializer) DeserializeLen() (int, error) {
+	ret, err := d.deserializeUleb128AsU32()
+	if ret > MaxSequenceLength {
+		return 0, errors.New("length is too large")
+	}
+	return int(ret), err
+}
+
+func (d *Deserializer) DeserializeStr() (string, error) {
+	bytes, err := d.DeserializeBytes()
+	return string(bytes), err
+}
+
+func (d *Deserializer) DeserializeBool() (bool, error) {
+	ret, err := d.buf.ReadByte()
+	return ret == 1, err
+}
+
+func (d *Deserializer) DeserializeUnit() (struct{}, error) {
+	return struct{}{}, nil
+}
+
+// DeserializeChar is unimplemented
+func (d *Deserializer) DeserializeChar() (rune, error) {
+	panic("unimplemented")
+}
+
+// DeserializeF32 is unimplemented
+func (d *Deserializer) DeserializeF32() (float32, error) {
+	panic("unimplemented")
+}
+
+// DeserializeF64 is unimplemented
+func (d *Deserializer) DeserializeF64() (float64, error) {
+	panic("unimplemented")
+}
+
+func (d *Deserializer) DeserializeU8() (uint8, error) {
+	ret, err := d.buf.ReadByte()
+	return uint8(ret), err
+}
+
+func (d *Deserializer) DeserializeU16() (uint16, error) {
+	var ret uint16
+	for i := 0; i < 8*2; i += 8 {
+		b, err := d.buf.ReadByte()
+		if err != nil {
+			return 0, err
+		}
+		ret = ret | uint16(b)<<i
+	}
+	return ret, nil
+}
+
+func (d *Deserializer) DeserializeU32() (uint32, error) {
+	var ret uint32
+	for i := 0; i < 8*4; i += 8 {
+		b, err := d.buf.ReadByte()
+		if err != nil {
+			return 0, err
+		}
+		ret = ret | uint32(b)<<i
+	}
+	return ret, nil
+}
+
+func (d *Deserializer) DeserializeU64() (uint64, error) {
+	var ret uint64
+	for i := 0; i < 8*8; i += 8 {
+		b, err := d.buf.ReadByte()
+		if err != nil {
+			return 0, err
+		}
+		ret = ret | uint64(b)<<i
+	}
+	return ret, nil
+}
+
+func (d *Deserializer) DeserializeU128() (serde.Uint128, error) {
+	low, err := d.DeserializeU64()
+	if err != nil {
+		return serde.Uint128{}, err
+	}
+	high, err := d.DeserializeU64()
+	if err != nil {
+		return serde.Uint128{}, err
+	}
+	return serde.Uint128{High: high, Low: low}, nil
+}
+
+func (d *Deserializer) DeserializeI8() (int8, error) {
+	ret, err := d.DeserializeU8()
+	return int8(ret), err
+}
+
+func (d *Deserializer) DeserializeI16() (int16, error) {
+	ret, err := d.DeserializeU16()
+	return int16(ret), err
+}
+
+func (d *Deserializer) DeserializeI32() (int32, error) {
+	ret, err := d.DeserializeU32()
+	return int32(ret), err
+}
+
+func (d *Deserializer) DeserializeI64() (int64, error) {
+	ret, err := d.DeserializeU64()
+	return int64(ret), err
+}
+
+func (d *Deserializer) DeserializeI128() (serde.Int128, error) {
+	low, err := d.DeserializeU64()
+	if err != nil {
+		return serde.Int128{}, err
+	}
+	high, err := d.DeserializeI64()
+	if err != nil {
+		return serde.Int128{}, err
+	}
+	return serde.Int128{High: high, Low: low}, nil
+}
+
+func (d *Deserializer) DeserializeVariantIndex() (uint32, error) {
+	return d.deserializeUleb128AsU32()
+}
+
+func (d *Deserializer) DeserializeOptionTag() (bool, error) {
+	return d.DeserializeBool()
+}
+
+func (d *Deserializer) GetBufferOffset() int {
+	return d.buf.Len()
+}
+
+// CheckThatKeySlicesAreIncreasing is unimplemented yet
+func (d *Deserializer) CheckThatKeySlicesAreIncreasing(key1, key2 serde.Slice) error {
+	panic("unimplemented")
+}
+
+func (d *Deserializer) deserializeUleb128AsU32() (uint32, error) {
+	value := uint64(0)
+	for shift := 0; shift < 32; shift += 7 {
+		byte, err := d.buf.ReadByte()
+		if err != nil {
+			return 0, err
+		}
+		digit := byte & 0x7F
+		value = value | (uint64(digit) << shift)
+
+		if value > maxUint32 {
+			return 0, errors.New("overflow while parsing uleb128-encoded uint32 value")
+		}
+		if digit == byte {
+			if shift > 0 && digit == 0 {
+				return 0, errors.New("invalid uleb128 number (unexpected zero digit)")
+			}
+			return uint32(value), nil
+		}
+	}
+	return 0, errors.New("overflow while parsing uleb128-encoded uint32 value")
+}

--- a/serde-generate/runtime/golang/src/lcs/lcs_test.go
+++ b/serde-generate/runtime/golang/src/lcs/lcs_test.go
@@ -1,0 +1,630 @@
+// Copyright (c) Facebook, Inc. and its affiliates
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+package lcs_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/facebookincubator/serde-reflection/lcs"
+	"github.com/facebookincubator/serde-reflection/serde"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSerializeDeserializeBytes(t *testing.T) {
+	cases := []struct {
+		target   []byte
+		expected []byte
+	}{
+		{
+			target:   []byte{1, 2, 38},
+			expected: []byte{3, 1, 2, 38},
+		},
+		{
+			target:   []byte{},
+			expected: []byte{0},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(fmt.Sprintf("%#v", tc.target), func(t *testing.T) {
+			s := new(lcs.Serializer)
+			d := lcs.NewDeserializer(tc.expected)
+
+			err := s.SerializeBytes(tc.target)
+			require.NoError(t, err)
+
+			deserialized, err := d.DeserializeBytes()
+			require.NoError(t, err)
+
+			assert.Equal(t, tc.expected, s.GetBytes())
+			assert.Equal(t, tc.target, deserialized)
+		})
+	}
+}
+
+func TestSerializeDeserializeStr(t *testing.T) {
+	cases := []struct {
+		target   string
+		expected []byte
+	}{
+		{
+			target:   "hello world!",
+			expected: []byte{12, 104, 101, 108, 108, 111, 32, 119, 111, 114, 108, 100, 33},
+		},
+		{
+			target:   "",
+			expected: []byte{0},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.target, func(t *testing.T) {
+			s := new(lcs.Serializer)
+			d := lcs.NewDeserializer(tc.expected)
+
+			err := s.SerializeStr(tc.target)
+			require.NoError(t, err)
+
+			deserialized, err := d.DeserializeStr()
+			require.NoError(t, err)
+
+			assert.Equal(t, tc.expected, s.GetBytes())
+			assert.Equal(t, tc.target, deserialized)
+		})
+	}
+}
+
+func TestSerializeDeserializeBool(t *testing.T) {
+	cases := []struct {
+		target   bool
+		expected []byte
+	}{
+		{
+			target:   true,
+			expected: []byte{1},
+		},
+		{
+			target:   false,
+			expected: []byte{0},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(fmt.Sprintf("%#v", tc.target), func(t *testing.T) {
+			s := new(lcs.Serializer)
+			d := lcs.NewDeserializer(tc.expected)
+
+			err := s.SerializeBool(tc.target)
+			require.NoError(t, err)
+
+			deserialized, err := d.DeserializeBool()
+			require.NoError(t, err)
+
+			assert.Equal(t, tc.expected, s.GetBytes())
+			assert.Equal(t, tc.target, deserialized)
+		})
+	}
+}
+
+func TestSerializeDeserializeUnit(t *testing.T) {
+	cases := []struct {
+		target   struct{}
+		expected []byte
+	}{
+		{
+			target:   struct{}{},
+			expected: []byte(nil),
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(fmt.Sprintf("%#v", tc.target), func(t *testing.T) {
+			s := new(lcs.Serializer)
+			d := lcs.NewDeserializer(tc.expected)
+
+			err := s.SerializeUnit(tc.target)
+			require.NoError(t, err)
+
+			deserialized, err := d.DeserializeUnit()
+			require.NoError(t, err)
+
+			assert.Equal(t, tc.expected, s.GetBytes())
+			assert.Equal(t, tc.target, deserialized)
+		})
+	}
+}
+
+func TestSerializeDeserializeU8(t *testing.T) {
+	cases := []struct {
+		target   uint8
+		expected []byte
+	}{
+		{
+			target:   ^uint8(0),
+			expected: []byte{^uint8(0)},
+		},
+		{
+			target:   0,
+			expected: []byte{0},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(fmt.Sprintf("%#v", tc.target), func(t *testing.T) {
+			s := new(lcs.Serializer)
+			d := lcs.NewDeserializer(tc.expected)
+
+			err := s.SerializeU8(tc.target)
+			require.NoError(t, err)
+
+			deserialized, err := d.DeserializeU8()
+			require.NoError(t, err)
+
+			assert.Equal(t, tc.expected, s.GetBytes())
+			assert.Equal(t, tc.target, deserialized)
+		})
+	}
+}
+
+func TestSerializeDeserializeU16(t *testing.T) {
+	cases := []struct {
+		target   uint16
+		expected []byte
+	}{
+		{
+			target:   ^uint16(0),
+			expected: []byte{^uint8(0), ^uint8(0)},
+		},
+		{
+			target:   0,
+			expected: []byte{0, 0},
+		},
+		{
+			target:   827,
+			expected: []byte{59, 3},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(fmt.Sprintf("%#v", tc.target), func(t *testing.T) {
+			s := new(lcs.Serializer)
+			d := lcs.NewDeserializer(tc.expected)
+
+			err := s.SerializeU16(tc.target)
+			require.NoError(t, err)
+
+			deserialized, err := d.DeserializeU16()
+			require.NoError(t, err)
+
+			assert.Equal(t, tc.expected, s.GetBytes())
+			assert.Equal(t, tc.target, deserialized)
+		})
+	}
+}
+
+func TestSerializeDeserializeU32(t *testing.T) {
+	cases := []struct {
+		target   uint32
+		expected []byte
+	}{
+		{
+			target:   ^uint32(0),
+			expected: []byte{^uint8(0), ^uint8(0), ^uint8(0), ^uint8(0)},
+		},
+		{
+			target:   0,
+			expected: []byte{0, 0, 0, 0},
+		},
+		{
+			target:   827,
+			expected: []byte{59, 3, 0, 0},
+		},
+		{
+			target:   321243314,
+			expected: []byte{178, 200, 37, 19},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(fmt.Sprintf("%#v", tc.target), func(t *testing.T) {
+			s := new(lcs.Serializer)
+			d := lcs.NewDeserializer(tc.expected)
+
+			err := s.SerializeU32(tc.target)
+			require.NoError(t, err)
+
+			deserialized, err := d.DeserializeU32()
+			require.NoError(t, err)
+
+			assert.Equal(t, tc.expected, s.GetBytes())
+			assert.Equal(t, tc.target, deserialized)
+		})
+	}
+}
+
+func TestSerializeDeserializeU64(t *testing.T) {
+	cases := []struct {
+		target   uint64
+		expected []byte
+	}{
+		{
+			target:   ^uint64(0),
+			expected: []byte{^uint8(0), ^uint8(0), ^uint8(0), ^uint8(0), ^uint8(0), ^uint8(0), ^uint8(0), ^uint8(0)},
+		},
+		{
+			target:   0,
+			expected: []byte{0, 0, 0, 0, 0, 0, 0, 0},
+		},
+		{
+			target:   827,
+			expected: []byte{59, 3, 0, 0, 0, 0, 0, 0},
+		},
+		{
+			target:   321243314,
+			expected: []byte{178, 200, 37, 19, 0, 0, 0, 0},
+		},
+		{
+			target:   2212444144212422242,
+			expected: []byte{98, 174, 44, 37, 58, 46, 180, 30},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(fmt.Sprintf("%#v", tc.target), func(t *testing.T) {
+			s := new(lcs.Serializer)
+			d := lcs.NewDeserializer(tc.expected)
+
+			err := s.SerializeU64(tc.target)
+			require.NoError(t, err)
+
+			deserialized, err := d.DeserializeU64()
+			require.NoError(t, err)
+
+			assert.Equal(t, tc.expected, s.GetBytes())
+			assert.Equal(t, tc.target, deserialized)
+		})
+	}
+}
+
+func TestSerializeDeserializeU128(t *testing.T) {
+	cases := []struct {
+		target   serde.Uint128
+		expected []byte
+	}{
+		{
+			target: serde.Uint128{
+				^uint64(0),
+				^uint64(0),
+			},
+			expected: []byte{
+				^uint8(0), ^uint8(0), ^uint8(0), ^uint8(0),
+				^uint8(0), ^uint8(0), ^uint8(0), ^uint8(0),
+				^uint8(0), ^uint8(0), ^uint8(0), ^uint8(0),
+				^uint8(0), ^uint8(0), ^uint8(0), ^uint8(0),
+			},
+		},
+		{
+			target: serde.Uint128{0, 0},
+			expected: []byte{
+				0, 0, 0, 0, 0, 0, 0, 0,
+				0, 0, 0, 0, 0, 0, 0, 0,
+			},
+		},
+		{
+			target: serde.Uint128{High: 0, Low: 321243314},
+			expected: []byte{
+				178, 200, 37, 19, 0, 0, 0, 0,
+				0, 0, 0, 0, 0, 0, 0, 0,
+			},
+		},
+		{
+			target: serde.Uint128{High: 321243314, Low: 827},
+			expected: []byte{
+				59, 3, 0, 0, 0, 0, 0, 0,
+				178, 200, 37, 19, 0, 0, 0, 0,
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(fmt.Sprintf("%#v", tc.target), func(t *testing.T) {
+			s := new(lcs.Serializer)
+			d := lcs.NewDeserializer(tc.expected)
+
+			err := s.SerializeU128(tc.target)
+			require.NoError(t, err)
+
+			deserialized, err := d.DeserializeU128()
+			require.NoError(t, err)
+
+			assert.Equal(t, tc.expected, s.GetBytes())
+			assert.Equal(t, tc.target, deserialized)
+		})
+	}
+}
+
+func TestSerializeDeserializeI8(t *testing.T) {
+	cases := []struct {
+		target   int8
+		expected []byte
+	}{
+		{
+			target:   ^int8(0),
+			expected: []byte{^uint8(0)},
+		},
+		{
+			target:   -^int8(0) - 1,
+			expected: []byte{0},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(fmt.Sprintf("%#v", tc.target), func(t *testing.T) {
+			s := new(lcs.Serializer)
+			d := lcs.NewDeserializer(tc.expected)
+
+			err := s.SerializeI8(tc.target)
+			require.NoError(t, err)
+
+			deserialized, err := d.DeserializeI8()
+			require.NoError(t, err)
+
+			assert.Equal(t, tc.expected, s.GetBytes())
+			assert.Equal(t, tc.target, deserialized)
+		})
+	}
+}
+
+func TestSerializeDeserializeI16(t *testing.T) {
+	cases := []struct {
+		target   int16
+		expected []byte
+	}{
+		{
+			target:   ^int16(0),
+			expected: []byte{^uint8(0), ^uint8(0)},
+		},
+		{
+			target:   0,
+			expected: []byte{0, 0},
+		},
+		{
+			target:   -2,
+			expected: []byte{254, 255},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(fmt.Sprintf("%#v", tc.target), func(t *testing.T) {
+			s := new(lcs.Serializer)
+			d := lcs.NewDeserializer(tc.expected)
+
+			err := s.SerializeI16(tc.target)
+			require.NoError(t, err)
+
+			deserialized, err := d.DeserializeI16()
+			require.NoError(t, err)
+
+			assert.Equal(t, tc.expected, s.GetBytes())
+			assert.Equal(t, tc.target, deserialized)
+		})
+	}
+}
+
+func TestSerializeDeserializeI32(t *testing.T) {
+	cases := []struct {
+		target   int32
+		expected []byte
+	}{
+		{
+			target:   ^int32(0),
+			expected: []byte{255, 255, 255, 255},
+		},
+		{
+			target:   0,
+			expected: []byte{0, 0, 0, 0},
+		},
+		{
+			target:   -232,
+			expected: []byte{24, 255, 255, 255},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(fmt.Sprintf("%#v", tc.target), func(t *testing.T) {
+			s := new(lcs.Serializer)
+			d := lcs.NewDeserializer(tc.expected)
+
+			err := s.SerializeI32(tc.target)
+			require.NoError(t, err)
+
+			deserialized, err := d.DeserializeI32()
+			require.NoError(t, err)
+
+			assert.Equal(t, tc.expected, s.GetBytes())
+			assert.Equal(t, tc.target, deserialized)
+		})
+	}
+}
+
+func TestSerializeDeserializeI64(t *testing.T) {
+	cases := []struct {
+		target   int64
+		expected []byte
+	}{
+		{
+			target: ^int64(0),
+			expected: []byte{
+				^uint8(0), ^uint8(0), ^uint8(0), ^uint8(0),
+				^uint8(0), ^uint8(0), ^uint8(0), ^uint8(0),
+			},
+		},
+		{
+			target:   0,
+			expected: []byte{0, 0, 0, 0, 0, 0, 0, 0},
+		},
+		{
+			target:   -232,
+			expected: []byte{24, 255, 255, 255, 255, 255, 255, 255},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(fmt.Sprintf("%#v", tc.target), func(t *testing.T) {
+			s := new(lcs.Serializer)
+			d := lcs.NewDeserializer(tc.expected)
+
+			err := s.SerializeI64(tc.target)
+			require.NoError(t, err)
+
+			deserialized, err := d.DeserializeI64()
+			require.NoError(t, err)
+
+			assert.Equal(t, tc.expected, s.GetBytes())
+			assert.Equal(t, tc.target, deserialized)
+		})
+	}
+}
+
+func TestSerializeDeserializeI128(t *testing.T) {
+	cases := []struct {
+		target   serde.Int128
+		expected []byte
+	}{
+		{
+			target: serde.Int128{^int64(0), ^uint64(0)},
+			expected: []byte{
+				^uint8(0), ^uint8(0), ^uint8(0), ^uint8(0),
+				^uint8(0), ^uint8(0), ^uint8(0), ^uint8(0),
+				^uint8(0), ^uint8(0), ^uint8(0), ^uint8(0),
+				^uint8(0), ^uint8(0), ^uint8(0), ^uint8(0),
+			},
+		},
+		{
+			target: serde.Int128{0, 0},
+			expected: []byte{
+				0, 0, 0, 0, 0, 0, 0, 0,
+				0, 0, 0, 0, 0, 0, 0, 0,
+			},
+		},
+		{
+			target: serde.Int128{High: -232, Low: 321243314},
+			expected: []byte{
+				178, 200, 37, 19, 0, 0, 0, 0,
+				24, 255, 255, 255, 255, 255, 255, 255,
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(fmt.Sprintf("%#v", tc.target), func(t *testing.T) {
+			s := new(lcs.Serializer)
+			d := lcs.NewDeserializer(tc.expected)
+
+			err := s.SerializeI128(tc.target)
+			require.NoError(t, err)
+
+			deserialized, err := d.DeserializeI128()
+			require.NoError(t, err)
+
+			assert.Equal(t, tc.expected, s.GetBytes())
+			assert.Equal(t, tc.target, deserialized)
+		})
+	}
+}
+
+func TestSerializeDeserializeVariantIndex(t *testing.T) {
+	cases := []struct {
+		target   uint32
+		expected []byte
+	}{
+		{
+			target:   9487,
+			expected: []byte{143, 74},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(fmt.Sprintf("%#v", tc.target), func(t *testing.T) {
+			s := new(lcs.Serializer)
+			d := lcs.NewDeserializer(tc.expected)
+
+			err := s.SerializeVariantIndex(tc.target)
+			require.NoError(t, err)
+
+			deserialized, err := d.DeserializeVariantIndex()
+			require.NoError(t, err)
+			assert.Equal(t, tc.expected, s.GetBytes())
+			assert.Equal(t, tc.target, deserialized)
+		})
+	}
+}
+
+func TestSerializeDeserializeLenLimit(t *testing.T) {
+	t.Run("negative len", func(t *testing.T) {
+		s := new(lcs.Serializer)
+		err := s.SerializeLen(-1)
+		assert.Error(t, err)
+		assert.Equal(t, "length must >= 0", err.Error())
+	})
+	t.Run("overflow", func(t *testing.T) {
+		s := new(lcs.Serializer)
+		err := s.SerializeVariantIndex(^uint32(0))
+		assert.NoError(t, err)
+
+		d := lcs.NewDeserializer(s.GetBytes())
+		ret, err := d.DeserializeLen()
+		assert.Equal(t, 0, ret)
+		require.Error(t, err)
+		assert.Equal(t, "length is too large", err.Error())
+	})
+
+	t.Run("overflow while parsing uleb128-encoded uint32", func(t *testing.T) {
+		d := lcs.NewDeserializer([]byte{255, 255, 255, 255, 255, 255, 255, 255})
+		_, err := d.DeserializeLen()
+		require.Error(t, err)
+		assert.Equal(t, "overflow while parsing uleb128-encoded uint32 value", err.Error())
+	})
+}
+
+func TestSerializeDeserializeOptionTag(t *testing.T) {
+	cases := []struct {
+		target   bool
+		expected []byte
+	}{
+		{
+			target:   true,
+			expected: []byte{1},
+		},
+		{
+			target:   false,
+			expected: []byte{0},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(fmt.Sprintf("%#v", tc.target), func(t *testing.T) {
+			s := new(lcs.Serializer)
+			d := lcs.NewDeserializer(tc.expected)
+
+			err := s.SerializeOptionTag(tc.target)
+			require.NoError(t, err)
+
+			deserialized, err := d.DeserializeOptionTag()
+			require.NoError(t, err)
+			assert.Equal(t, tc.expected, s.GetBytes())
+			assert.Equal(t, tc.target, deserialized)
+		})
+	}
+}
+
+func TestGetBufferOffset(t *testing.T) {
+	s := new(lcs.Serializer)
+	s.SerializeU64(0)
+	assert.Equal(t, s.GetBufferOffset(), 8)
+	d := lcs.NewDeserializer([]byte{0, 0, 0, 0, 0, 0, 0, 0})
+	assert.Equal(t, d.GetBufferOffset(), 8)
+}

--- a/serde-generate/runtime/golang/src/lcs/serializer.go
+++ b/serde-generate/runtime/golang/src/lcs/serializer.go
@@ -1,0 +1,159 @@
+// Copyright (c) Facebook, Inc. and its affiliates
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+package lcs
+
+import (
+	"bytes"
+	"errors"
+
+	"github.com/facebookincubator/serde-reflection/serde"
+)
+
+// Serializer implements `serde.Serializer` interface for serializing LCS bytes
+type Serializer struct {
+	buf bytes.Buffer
+}
+
+// NewSerializer creates a new `serde.Serializer`
+func NewSerializer() serde.Serializer {
+	return new(Serializer)
+}
+
+func (s *Serializer) GetBytes() []byte {
+	return s.buf.Bytes()
+}
+
+func (s *Serializer) SerializeLen(value int) error {
+	if value < 0 {
+		return errors.New("length must >= 0")
+	}
+	s.serializeU32AsUleb128(uint32(value))
+	return nil
+}
+
+func (s *Serializer) SerializeBytes(value []byte) error {
+	s.SerializeLen(len(value))
+	s.buf.Write(value)
+	return nil
+}
+
+func (s *Serializer) SerializeStr(value string) error {
+	return s.SerializeBytes([]byte(value))
+}
+
+func (s *Serializer) SerializeBool(value bool) error {
+	if value {
+		return s.buf.WriteByte(1)
+	}
+	return s.buf.WriteByte(0)
+}
+
+func (s *Serializer) SerializeUnit(value struct{}) error {
+	return nil
+}
+
+// SerializeChar is unimplemented
+func (s *Serializer) SerializeChar(value rune) error {
+	panic("unimplemented")
+}
+
+// SerializeF32 is unimplemented
+func (s *Serializer) SerializeF32(value float32) error {
+	panic("unimplemented")
+}
+
+// SerializeF64 is unimplemented
+func (s *Serializer) SerializeF64(value float64) error {
+	panic("unimplemented")
+}
+
+func (s *Serializer) SerializeU8(value uint8) error {
+	s.buf.WriteByte(byte(value))
+	return nil
+}
+
+func (s *Serializer) SerializeU16(value uint16) error {
+	s.buf.WriteByte(byte(value))
+	s.buf.WriteByte(byte(value >> 8))
+	return nil
+}
+
+func (s *Serializer) SerializeU32(value uint32) error {
+	s.buf.WriteByte(byte(value))
+	s.buf.WriteByte(byte(value >> 8))
+	s.buf.WriteByte(byte(value >> 16))
+	s.buf.WriteByte(byte(value >> 24))
+	return nil
+}
+
+func (s *Serializer) SerializeU64(value uint64) error {
+	s.buf.WriteByte(byte(value))
+	s.buf.WriteByte(byte(value >> 8))
+	s.buf.WriteByte(byte(value >> 16))
+	s.buf.WriteByte(byte(value >> 24))
+	s.buf.WriteByte(byte(value >> 32))
+	s.buf.WriteByte(byte(value >> 40))
+	s.buf.WriteByte(byte(value >> 48))
+	s.buf.WriteByte(byte(value >> 56))
+	return nil
+}
+
+func (s *Serializer) SerializeU128(value serde.Uint128) error {
+	s.SerializeU64(value.Low)
+	s.SerializeU64(value.High)
+	return nil
+}
+
+func (s *Serializer) SerializeI8(value int8) error {
+	s.SerializeU8(uint8(value))
+	return nil
+}
+
+func (s *Serializer) SerializeI16(value int16) error {
+	s.SerializeU16(uint16(value))
+	return nil
+}
+
+func (s *Serializer) SerializeI32(value int32) error {
+	s.SerializeU32(uint32(value))
+	return nil
+}
+
+func (s *Serializer) SerializeI64(value int64) error {
+	s.SerializeU64(uint64(value))
+	return nil
+}
+
+func (s *Serializer) SerializeI128(value serde.Int128) error {
+	s.SerializeU64(value.Low)
+	s.SerializeI64(value.High)
+	return nil
+}
+
+func (s *Serializer) SerializeVariantIndex(value uint32) error {
+	s.serializeU32AsUleb128(value)
+	return nil
+}
+
+func (s *Serializer) SerializeOptionTag(value bool) error {
+	return s.SerializeBool(value)
+}
+
+func (s *Serializer) GetBufferOffset() int {
+	return s.buf.Len()
+}
+
+// SortMapEntries is unimplemented yet
+func (s *Serializer) SortMapEntries(offsets []int) {
+	panic("unimplemented")
+}
+
+func (s *Serializer) serializeU32AsUleb128(value uint32) {
+	for value >= 0x80 {
+		b := byte((value & 0x7f) | 0x80)
+		_ = s.buf.WriteByte(b)
+		value = value >> 7
+	}
+	_ = s.buf.WriteByte(byte(value))
+}

--- a/serde-generate/runtime/golang/src/serde/interfaces.go
+++ b/serde-generate/runtime/golang/src/serde/interfaces.go
@@ -88,11 +88,11 @@ type Deserializer interface {
 
 	DeserializeLen() (int, error)
 
-	DeserializeVariantIndex() (uint64, error)
+	DeserializeVariantIndex() (uint32, error)
 
 	DeserializeOptionTag() (bool, error)
 
-	GetBufferOffset() uint64
+	GetBufferOffset() int
 
 	CheckThatKeySlicesAreIncreasing(key1, key2 Slice) error
 }


### PR DESCRIPTION
## Summary

First round implementing golang lcs serializer & deserializer.
Map is not supported yet, will have follow up change to implement.

Note: added go module under golang/src for now, otherwise we need use "github.com/facebookincubator/serde-reflection/src/lcs" instead of "github.com/facebookincubator/serde-reflection/lcs" to import, maybe we should remove "src", seems not necessary in golang.

## Test Plan

Unit test
